### PR TITLE
Release/v2.0.0

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -45,6 +45,10 @@ jobs:
           rm ./.gitignore
           rm composer.json
           rm composer.lock
+          rm .csscomb.json
+          rm .gitmodules
+          rm public/assets/document-formats/.git
+          rm public/assets/document-formats/README.md
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,10 @@ jobs:
           rm .gitignore
           rm composer.json
           rm composer.lock
+          rm .csscomb.json
+          rm .gitmodules
+          rm public/assets/document-formats/.git
+          rm public/assets/document-formats/README.md
       - name: Build Artifact
         run: zip -r onlyoffice.zip onlyoffice/
       - name: Generate Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## Added
 - multisite support
 - stub for onlyoffice-wordpress-block that displays error information if the document server is not accessible or the file is not found 
-- settings for onlyoffice block (width, height, align, show open in onlyoffice bytton)
+- settings for onlyoffice block (width, height, align, show open in onlyoffice button)
 - button copy link to editor, in the table with files
 - ability to insert a link to the editor on the page
 - access for an anonymous user, open the document for viewing in the editor if the document is attached to a public post

--- a/controllers/class-onlyoffice-plugin-frontend-controller.php
+++ b/controllers/class-onlyoffice-plugin-frontend-controller.php
@@ -203,7 +203,11 @@ class Onlyoffice_Plugin_Frontend_Controller {
 
 		$output  = '<div class="wp-block-onlyoffice-wordpress-onlyoffice ' . $align . '">';
 		$output .= '<a id="linkToOnlyofficeEditor-' . $instance . '" href="' . Onlyoffice_Plugin_Url_Manager::get_editor_url( $atts['id'] ) . '" ' . $target . '>' . $atts['fileName'] . '</a>';
-		$output .= '<a href="' . Onlyoffice_Plugin_Url_Manager::get_editor_url( $atts['id'] ) . '" ' . $target . ' class="wp-block-onlyoffice-wordpress__button wp-element-button">' . $atts['openButtonText'] . '</a>';
+
+		if ( $atts['showOpenButton'] ) {
+			$output .= '<a href="' . Onlyoffice_Plugin_Url_Manager::get_editor_url( $atts['id'] ) . '" ' . $target . ' class="wp-block-onlyoffice-wordpress__button wp-element-button">' . $atts['openButtonText'] . '</a>';
+		}
+
 		$output .= '</div>';
 
 		return apply_filters( 'wp_onlyoffice_shortcode', $output, $atts );

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,26 @@ You can co-author documents using real-time or paragraph-locking co-eding modes,
 7. ONLYOFFICE file available for viewing in the Embedded mode to the WordPress site visitors.
 
 == Changelog ==
+= 2.0.0 =
+* multisite support
+* stub for onlyoffice-wordpress-block that displays error information if the document server is not accessible or the file is not found 
+* settings for onlyoffice block (width, height, align, show open in onlyoffice bytton)
+* button copy link to editor, in the table with files
+* ability to insert a link to the editor on the page
+* access for an anonymous user, open the document for viewing in the editor if the document is attached to a public post
+* filling pdf
+* editor url
+* displaying the onlyoffice-wordpress-block component in the Gutenberg editor
+* remove filling for oform
+* supported formats updated
+
+= 1.1.0 =
+* extended list of supported formats
+* support docxf and oform formats
+* support for the connector to work in conjunction with the plugin "Force Lowercase URLs" (https://wordpress.org/plugins/force-lowercase-urls)
+* setting authorization header
+* compatible with classic editor TinyMCE
+* Link to docs cloud
 
 = 1.0.2 =
 * fixed issues for the marketplace release

--- a/readme.txt
+++ b/readme.txt
@@ -84,8 +84,3 @@ You can co-author documents using real-time or paragraph-locking co-eding modes,
 * detecting mobile browser
 * set favicon on editor page
 * added goBack url for document editor
-
-== Upgrade Notice ==
-
-= 1.0 =
-This is the first version of the plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,7 @@ You can co-author documents using real-time or paragraph-locking co-eding modes,
 = 2.0.0 =
 * multisite support
 * stub for onlyoffice-wordpress-block that displays error information if the document server is not accessible or the file is not found 
-* settings for onlyoffice block (width, height, align, show open in onlyoffice bytton)
+* settings for onlyoffice block (width, height, align, show open in onlyoffice button)
 * button copy link to editor, in the table with files
 * ability to insert a link to the editor on the page
 * access for an anonymous user, open the document for viewing in the editor if the document is attached to a public post


### PR DESCRIPTION
## Added
- multisite support
- stub for onlyoffice-wordpress-block that displays error information if the document server is not accessible or the file is not found 
- settings for onlyoffice block (width, height, align, show open in onlyoffice bytton)
- button copy link to editor, in the table with files
- ability to insert a link to the editor on the page
- access for an anonymous user, open the document for viewing in the editor if the document is attached to a public post
- filling pdf

## Changed
- editor url
- displaying the onlyoffice-wordpress-block component in the Gutenberg editor
- remove filling for oform
- supported formats updated